### PR TITLE
Handling of order constraints (closes #8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15716,7 +15716,7 @@
     "node_modules/wydependencytreejsiwys": {
       "version": "2.4.4",
       "resolved": "file:../wyDependencyTreeJSiwys/wydependencytreejsiwys-2.4.4.tgz",
-      "integrity": "sha512-0+z0S0h2bluTcdaM6a/s22sRmwo/VjyYwdKi8/7aMBQcF5yK764jlHpeTWa9mUruv5b+WOgiLNdYlDCsc0/+Yg==",
+      "integrity": "sha512-SVhbHnaSoj7L03x1r5RaEflgPmy+xfmFtakOtJmf53Gda/zMxqu+EghatTaXukhUKEfxaBXFg6RL26YyBjyckA==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@types/snapsvg": "^0.5.0",

--- a/public/index.html
+++ b/public/index.html
@@ -1,15 +1,15 @@
 <script src="../dist/wytiwys.umd.js" async deferred></script>
 
-<reactive-dep-tree interactive="true" shown-features="UPOS,LEMMA,FORM" conll="
-# text = It was not possible to add or remove nodes.
-1	It	it	PRON	_	_	4	expl	_	_
-2	was	be	AUX	_	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	cop	_	_
-3	not	not	PART	_	Polarity=Neg	4	advmod	_	_
-4	possible	possible	ADJ	_	Degree=Pos	0	root	_	_
-5	to	to	PART	_	_	6	mark	_	_
-6	add	add	VERB	_	VerbForm=Inf	4	acl	_	_
-7	or	or	CCONJ	_	_	8	cc	_	_
-8	remove	remove	VERB	_	VerbForm=Inf	6	conj	_	_
-9	nodes	node	NOUN	_	Number=Plur	8	obj	_	SpaceAfter=No
-10	.	.	PUNCT	_	_	4	punct	_	_
+<reactive-dep-tree interactive="true" shown-features="UPOS,LEMMA,FORM,MISC.ordered" conll="
+1-2	It's	_	_	_	_	_	_	_	TokenRange=0:4
+1	It	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
+2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	aux	_	_
+3	beginning	begin	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	_	TokenRange=5:14
+4	to	to	PART	TO	_	5	mark	_	TokenRange=15:17
+5	look	look	VERB	VB	VerbForm=Inf	3	xcomp	_	TokenRange=18:22
+6	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	_	TokenRange=23:24
+7	lot	lot	NOUN	NN	Number=Sing	5	obl:unmarked	_	TokenRange=25:28
+8	like	like	ADP	IN	_	9	case	_	TokenRange=29:33
+9	Christmas	Christmas	PROPN	NNP	Number=Sing	5	obl	_	SpaceAfter=No|TokenRange=34:43
+10	...	...	PUNCT	.	_	3	punct	_	SpaceAfter=No|TokenRange=43:46
 "></reactive-dep-tree>

--- a/src/ReactiveDepTree.vue
+++ b/src/ReactiveDepTree.vue
@@ -130,12 +130,31 @@ export default {
       this.sentenceBus.$emit("reset:allDialog");
       const targetLabel = e.detail.targetLabel;
       const tokenId = e.detail.clicked;
+      const svgPosition = this.sentenceSVG.tokenIndexToSvgPosition[tokenId];
+
+    // just an internal function (lambda) wrapping reactiveSentence.toggleBoolFeat with UI stuff cause I don't know better...
+    const toggle = (feat) => {
+      const button = this.sentenceSVG.tokenSVGs[svgPosition].snapElements[targetLabel];
+      const active = this.reactiveSentence.toggleBoolFeat(tokenId, feat);
+      if (active) {
+        button.removeClass("inactive");
+      } else {
+        button.addClass("inactive");
+      }
+    }
+
       if (targetLabel == "ADD_AFTER") {
         this.reactiveSentence.addEmptyTokenAfter(tokenId);
       } else if (targetLabel == "ADD_BEFORE") {
         this.reactiveSentence.addEmptyTokenBefore(tokenId);
       } else if (targetLabel == "REMOVE") {
         this.reactiveSentence.removeToken(tokenId);
+      } else if (targetLabel.startsWith("ANCHOR")) {
+        toggle("anchored");
+      } else if (targetLabel == "CHAIN") {
+        toggle("subsequent");
+      } else if (targetLabel == "LOCK") {
+        toggle("ordered");
       } else {
         this.sentenceBus.$emit("open:editDialog", {
           ID: tokenId,


### PR DESCRIPTION
So @Niklas-Deworetzki! Slowly but surely, we transition from depencency to xmas trees:

<img width="1617" height="829" alt="image" src="https://github.com/user-attachments/assets/49c60fa6-dfa2-4022-a413-9ecb04b7c9f9" />

Legenda for the different decorations:
1. the locks toggles a feature that I ended up calling `ordered`
2. the two anchors toggle `anchored`
3. the chains toggle `subsequent` on the _following_ node (so "s" is subsequent to "It"). 

I know that in #8 we initially said the __adjacency constraints__ (3) would be on the first of the two adjacent nodes, but when it came to centering the icon between tokens it was easier this way (and still, hardest part of this project so far :laughing:). I also know we discussed a different __naming convention__ for features, but is suspect using `Query.Xyz` would require forking a third repository and fixing how dots are handled (which I'm trying to avoid), and the guy who wrote the code we are forking already had a convention of using lowercase misc item names for things that are non-UD (e.g. `highlight`, which is for application-internal use), so I figured we could follow that.
Let me know if you have any objection to either.

__Known issue__: untoggling (by clicking on a toggle icon a second time) correctly updates the opacity of the icon and the underlying CoNLL-U, but not the features visible under the tree (if enabled; not in this screenshot). I'm trying to figure out what notify/update/... incantation I forgot, but in any case, if you ask me these lowercase features should never be displayed - doing so should not even be offered as an option in #2.

(as always, all the heavy lifting is done in the other repo, see https://github.com/harisont/wyDependencyTreeJSiwys/pull/4)
